### PR TITLE
New validation.

### DIFF
--- a/src/demo/demo-app.html
+++ b/src/demo/demo-app.html
@@ -39,9 +39,12 @@
                 </ul>
             </div>
             <form if.bind="selectedTab == 0">
-                <mdc-text-field id="emailInput" label="Email" helper-text="Please enter a valid email address" type="text" model.bind="demoModel"
-                    property="email" required="true" autofocus="true" maxlength="25"></mdc-text-field>
-                <mdc-text-field id="numericInput" label="Numeric" type="number" model.bind="demoModel" property="numeric" required="true"></mdc-text-field>
+                <mdc-text-field id="emailInput" label="Email" helper-text="Please enter a valid email address" type="text" 
+                    value.bind="demoModel.email & validate"
+                    required="true" autofocus="true" maxlength="25" mdc-validation-errors>
+                </mdc-text-field>
+                <mdc-text-field id="numericInput" label="Numeric" type="number" 
+                    value.bind="demoModel.numeric & validate" required="true" mdc-validation-errors></mdc-text-field>
                 <mdc-slider id="input3" discrete="true" markers="true" value.bind="demoModel.numeric" valuemax="100" label="Numeric via slider"></mdc-slider>
                 <mdc-switch id="input4" label="Switch me" checked.two-way="demoModel.checked & validate"></mdc-switch>
                 <div class="progress">  

--- a/src/demo/demo-app.html
+++ b/src/demo/demo-app.html
@@ -46,7 +46,7 @@
                 <mdc-text-field id="numericInput" label="Numeric" type="number" 
                     value.bind="demoModel.numeric & validate" required="true" mdc-validation-errors></mdc-text-field>
                 <mdc-slider id="input3" discrete="true" markers="true" value.bind="demoModel.numeric" valuemax="100" label="Numeric via slider"></mdc-slider>
-                <mdc-switch id="input4" label="Switch me" checked.two-way="demoModel.checked & validate"></mdc-switch>
+                <mdc-switch id="input4" label="Switch me" checked.two-way="demoModel.checked & validate" required="true" mdc-validation-errors></mdc-switch>
                 <div class="progress">  
                     <mdc-linear-progress open.bind="demoModel.checked" value.bind="demoModel.percentage"></mdc-linear-progress>
                 </div>

--- a/src/demo/demo-app.html
+++ b/src/demo/demo-app.html
@@ -41,7 +41,7 @@
             <form if.bind="selectedTab == 0">
                 <mdc-text-field id="emailInput" label="Email" helper-text="Please enter a valid email address" type="text" 
                     value.bind="demoModel.email & validate"
-                    required="true" autofocus="true" maxlength="25" mdc-validation-errors>
+                    required.bind="true" autofocus="true" maxlength="25" mdc-validation-errors>
                 </mdc-text-field>
                 <mdc-text-field id="numericInput" label="Numeric" type="number" 
                     value.bind="demoModel.numeric & validate" required="true" mdc-validation-errors></mdc-text-field>

--- a/src/demo/demo-model.ts
+++ b/src/demo/demo-model.ts
@@ -1,7 +1,7 @@
 
 export class DemoModel {
     email: string = "";
-    numeric: number = 1;
+    numeric: number = null;
     checked: boolean = false;
     selected: string = "";
 

--- a/src/mdc/index.ts
+++ b/src/mdc/index.ts
@@ -3,6 +3,7 @@ import { FrameworkConfiguration, PLATFORM } from 'aurelia-framework';
 export function configure(config: FrameworkConfiguration) {
   config.globalResources([
     PLATFORM.moduleName("./mdc-ripple"),
+    PLATFORM.moduleName("./mdc-validation-errors"),
     PLATFORM.moduleName("./drawer/mdc-drawer"),
     PLATFORM.moduleName("./linear-progress/mdc-linear-progress"),
     PLATFORM.moduleName("./slider/mdc-slider"),

--- a/src/mdc/mdc-validation-errors.ts
+++ b/src/mdc/mdc-validation-errors.ts
@@ -15,6 +15,13 @@ export class MdcValidationRenderer implements ValidationRenderer {
     bind(context: any) {
         this.controller = this.controllerAccessor();
         this.controller.addRenderer(this);
+
+        const inputElement = this.element.querySelector("input");
+        if (inputElement) {
+            inputElement.onblur = (ev: FocusEvent) => {
+                this.element.dispatchEvent(new FocusEvent("blur"));
+            };
+        }
     }
 
     public render(instruction: RenderInstruction) {

--- a/src/mdc/mdc-validation-errors.ts
+++ b/src/mdc/mdc-validation-errors.ts
@@ -1,0 +1,48 @@
+import { bindable, Lazy, inject, bindingMode, customAttribute } from "aurelia-framework";
+import { ValidationController, ValidationRenderer, RenderInstruction } from "aurelia-validation";
+
+@inject(Lazy.of(ValidationController), Element)
+@customAttribute('mdc-validation-errors')
+export class MdcValidationRenderer implements ValidationRenderer {
+    @bindable internalErrors: any[] = [];
+
+    @bindable({ defaultBindingMode: bindingMode.oneWay })
+    public controller: ValidationController | null = null;
+
+    constructor(private controllerAccessor: () => ValidationController, private element: Element) {
+    }
+
+    bind(context: any) {
+        this.controller = this.controllerAccessor();
+        this.controller.addRenderer(this);
+    }
+
+    public render(instruction: RenderInstruction) {
+        if (instruction.kind == "validate") {
+
+            // build internal errors
+            this.internalErrors.splice(0);
+            if (instruction.render.length > 0) {
+                for (var resultInstruction of instruction.render) {
+                    if (resultInstruction.elements.length > 0) {
+                        var resultElement = resultInstruction.elements[0];
+                        if (resultElement.contains(this.element)) {
+                            if (!resultInstruction.result.valid) {
+                                this.internalErrors.push(resultInstruction.result.message);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // try to update the errors bindable property for the custom element where this is an custom attribute of
+            const au = (<any>this.element).au;
+            if (au) {
+                const viewModel = au.controller.viewModel;
+                if (viewModel) {
+                    viewModel.validationErrors = this.internalErrors;
+                }
+            }
+        }
+    }
+}

--- a/src/mdc/mdc-validation-errors.ts
+++ b/src/mdc/mdc-validation-errors.ts
@@ -1,10 +1,10 @@
 import { bindable, Lazy, inject, bindingMode, customAttribute } from "aurelia-framework";
-import { ValidationController, ValidationRenderer, RenderInstruction } from "aurelia-validation";
+import { ValidationController, ValidationRenderer, RenderInstruction, ValidateResult } from "aurelia-validation";
 
 @inject(Lazy.of(ValidationController), Element)
 @customAttribute('mdc-validation-errors')
 export class MdcValidationRenderer implements ValidationRenderer {
-    @bindable internalErrors: any[] = [];
+    @bindable internalErrors: ValidateResult[] = [];
 
     @bindable({ defaultBindingMode: bindingMode.oneWay })
     public controller: ValidationController | null = null;
@@ -22,33 +22,40 @@ export class MdcValidationRenderer implements ValidationRenderer {
                 this.element.dispatchEvent(new FocusEvent("blur"));
             };
         }
+        const selectElement = this.element.querySelector("select");
+        if (selectElement) {
+            selectElement.onblur = (ev: FocusEvent) => {
+                this.element.dispatchEvent(new FocusEvent("blur"));
+            };
+        }
+    }
+
+    public unbind() {
+        this.controller.removeRenderer(this);
     }
 
     public render(instruction: RenderInstruction) {
-        if (instruction.kind == "validate") {
-
-            // build internal errors
-            this.internalErrors.splice(0);
-            if (instruction.render.length > 0) {
-                for (var resultInstruction of instruction.render) {
-                    if (resultInstruction.elements.length > 0) {
-                        var resultElement = resultInstruction.elements[0];
-                        if (resultElement.contains(this.element)) {
-                            if (!resultInstruction.result.valid) {
-                                this.internalErrors.push(resultInstruction.result.message);
-                            }
-                        }
-                    }
-                }
+        for (const { result } of instruction.unrender) {
+            const index = this.internalErrors.findIndex(x => x === result);
+            if (index !== -1) {
+                this.internalErrors.splice(index, 1);
             }
+        }
 
-            // try to update the errors bindable property for the custom element where this is an custom attribute of
-            const au = (<any>this.element).au;
-            if (au) {
-                const viewModel = au.controller.viewModel;
-                if (viewModel) {
-                    viewModel.validationErrors = this.internalErrors;
-                }
+        for (const { result, elements } of instruction.render) {
+            var targets = elements.filter(e => e.contains(this.element));
+            if (targets.length > 0) {
+                this.internalErrors.push(result);
+            }
+        }
+
+        // try to update the errors bindable property for the custom element where this is an custom attribute of
+        const au = (<any>this.element).au;
+        if (au) {
+            const viewModel = au.controller.viewModel;
+            if (viewModel) {
+                const validationErrors = this.internalErrors.filter(e => !e.valid).map(e => e.message);
+                viewModel.validationErrors = validationErrors;
             }
         }
     }

--- a/src/mdc/select/README.md
+++ b/src/mdc/select/README.md
@@ -3,6 +3,17 @@
 
 This a Select component that uses a native select
 
+## Example
+
+```html
+<mdc-select id="selectInput" 
+            label="Fruit" 
+            selected.bind="selectedFruit" 
+            choose="Select a fruit" 
+            options="Banana,Orange,Apple">
+</mdc-select>
+```
+
 ## Attributes
 
 1. `id` is the identifier of the element and must have an unique value (**required**);
@@ -10,6 +21,8 @@ This a Select component that uses a native select
 3. `selected` is the where the selected value is stored;
 4. `choose` is a text that is shown when the select has nothing selected (yet);
 5. `options` is a commma separated list op options
+6. `helperText` is a text that is shown when the select has focus and there is no error;
+7. `required` indicates if the select is a required field; is independent of the Aurelia validation required(), so both must be set;
 
 You can also not use the `choose` and `options` attributes and make your own list of `option` tags.
 
@@ -22,13 +35,6 @@ You can also not use the `choose` and `options` attributes and make your own lis
 </template>
 ```
 
-## Example
+## Important
 
-```html
-<mdc-select id="selectInput" 
-            label="Fruit" 
-            selected.bind="selectedFruit" 
-            choose="Select a fruit" 
-            options="Banana,Orange,Apple">
-</mdc-select>
-```
+You need to add the `mdc-validation-errors` custom attribute and an `validate` value behavior on the `value` attribute to make the validation work.

--- a/src/mdc/select/mdc-select.html
+++ b/src/mdc/select/mdc-select.html
@@ -8,7 +8,19 @@
                 </option>
             </template>
         </select>
-        <label id="${id}-label" class="mdc-floating-label">${label}</label>
+        <label id="${id}-label" class="mdc-floating-label">${label}${required?"*":""}</label>
         <div class="mdc-line-ripple"></div>
     </div>
+    <p id="${id}-helpertext-val-msg"
+       class="mdc-select-helper-text mdc-select-helper-text--persistent mdc-select-helper-text--validation-msg"
+       aria-hidden="true" 
+       if.bind="validationErrors.length>0">
+       <span class="help-block" repeat.for="error of validationErrors">${error}</span>
+    </p>
+    <p id="${id}-helpertext" 
+       class="mdc-select-helper-text" 
+       aria-hidden="true" 
+       if.bind="validationErrors.length==0 && helperText">
+           ${helperText}
+    </p>
 </template>

--- a/src/mdc/select/mdc-select.scss
+++ b/src/mdc/select/mdc-select.scss
@@ -7,4 +7,12 @@ mdc-select {
     > div {
         width: 100%;
     }
+
+    .mdc-select-helper-text {
+        padding-bottom: 6px;
+    }
+
+    .mdc-select-helper-text--validation-msg {
+        color: red !important;
+    }
 }

--- a/src/mdc/select/mdc-select.ts
+++ b/src/mdc/select/mdc-select.ts
@@ -12,8 +12,17 @@ export class MdcSelect
     @bindable({defaultBindingMode: bindingMode.twoWay}) selected: any;
     @bindable choose: string;
     @bindable options: string;
+    @bindable required: boolean|string = true;
+    @bindable helperText: string;
+    @bindable validationErrors: any[] = [];
  
     constructor(private element: Element){   
+    }
+
+    bind() {
+        if(this.required === "true" || this.required === "required") {
+            this.required = true;
+        }
     }
 
     attached()

--- a/src/mdc/switch/README.md
+++ b/src/mdc/switch/README.md
@@ -1,8 +1,25 @@
 
 # Material Design Switch component
 
+## Example
+
+```html
+<mdc-switch 
+    id="switch-input" 
+    label="Switch me" 
+    checked.bind="checked & validate" 
+    required="true" 
+    mdc-validation-errors>
+</mdc-switch>
+```
+
 ## Attributes
 
 1. `id` is the identifier of the element and must have an unique value (**required**);
-2. `label` holds the label
-3. `checked` is the boolean value of the switch
+2. `label` holds the label;
+3. `checked` is the boolean value of the switch;
+4. `required` indicates if the input is a required field; is independent of the Aurelia validation required(), so both must be set.
+
+## Important
+
+You need to add the `mdc-validation-errors` custom attribute and an `validate` value behavior on the `value` attribute to make the validation work.

--- a/src/mdc/switch/mdc-switch.html
+++ b/src/mdc/switch/mdc-switch.html
@@ -7,5 +7,5 @@
             </div>
         </div>
     </div>
-    <label for="${id}-input">${label}</label>
+    <label for="${id}-input" class="${valid?'':'validation-error'}">${label}${required?"*":""}</label>
 </template>

--- a/src/mdc/switch/mdc-switch.scss
+++ b/src/mdc/switch/mdc-switch.scss
@@ -2,4 +2,8 @@
 
 mdc-switch {
     display: block;
+
+    label.validation-error {
+        color: red;
+    }
 }

--- a/src/mdc/switch/mdc-switch.ts
+++ b/src/mdc/switch/mdc-switch.ts
@@ -7,19 +7,26 @@ import './mdc-switch.scss';
 export class MdcSwitch {
     private switch: MDCSwitch;
     @bindable id: string;
-    @bindable label: string;
+    @bindable label: string
+    @bindable required: boolean|string;
     @bindable({ defaultBindingMode: bindingMode.fromView }) checked: boolean = false;
+    @bindable validationErrors: any[] = [];
 
     constructor(private element: Element) {
+    }
+
+    bind() {
+        if(this.required === "true" || this.required === "required") {
+            this.required = true;
+        }
     }
 
     attached() {
         const element = this.element.querySelector(".mdc-switch");
         this.switch = new MDCSwitch(element);
+    }
 
-        const input = this.element.querySelector("input");
-        input.onblur = (ev:FocusEvent) => {
-            this.element.dispatchEvent(new FocusEvent("blur"));
-        };
+    get valid() {
+        return this.validationErrors.length == 0;
     }
 }

--- a/src/mdc/switch/mdc-switch.ts
+++ b/src/mdc/switch/mdc-switch.ts
@@ -8,7 +8,7 @@ export class MdcSwitch {
     private switch: MDCSwitch;
     @bindable id: string;
     @bindable label: string;
-    @bindable({ defaultBindingMode: bindingMode.twoWay }) checked: boolean = false;
+    @bindable({ defaultBindingMode: bindingMode.fromView }) checked: boolean = false;
 
     constructor(private element: Element) {
     }

--- a/src/mdc/text-field/README.md
+++ b/src/mdc/text-field/README.md
@@ -2,19 +2,32 @@
 # Material Design TextField components
 
 This a TextField component that integrates with Aurelia validation. 
-Aurelia validation works on objects, so that is why you will have to pass a model and a property name.
+
+## Example
+
+```html
+<mdc-text-field 
+    id="emailInput" 
+    label="Email"
+    value.bind="email & validate"
+    required="true" maxlength="25" 
+    mdc-validation-errors>
+</mdc-text-field>
+```
 
 ## Attributes
 
 1. `id` is the identifier of the element and must have an unique value (**required**);
-2. `model` is required and must be bound to an object that has an Aurelia validation bound to it (**required**);
-3. `property` is required and is the name of the property in `model` that is edited (**required**);
-4. `label` is the label shown above the text field;
-5. `type` is the type of the input; default `text`;
-6. `helperText` is a text that is shown when the input has focus and there is no error;
-7. `required` indicates if the input is a required field; is independent of the Aurelia validation required(), so both must be set;
-8. `disabled`: indicates if the input is disabled;
-9. `autofocus`: indicates if the text-field must have autofocus;
-10. `autocomplete`: sets the autocomplete value; default `on`;
-11. `max-length`: set the maximum length that a user can fill in; is independent of the Aurelia validation maxLength(), so both must be set;
+2. `value` is required and could be bound to a property that has an Aurelia validation bound to it (**required**);
+3. `label` is the label shown above the text field;
+4. `type` is the type of the input; default `text`;
+5. `helperText` is a text that is shown when the input has focus and there is no error;
+6. `required` indicates if the input is a required field; is independent of the Aurelia validation required(), so both must be set;
+7. `disabled`: indicates if the input is disabled;
+8. `autofocus`: indicates if the text-field must have autofocus;
+9. `autocomplete`: sets the autocomplete value; default `on`;
+10. `max-length`: set the maximum length that a user can fill in; is independent of the Aurelia validation maxLength(), so both must be set;
 
+## Important
+
+You need to add the `mdc-validation-errors` custom attribute and an `validate` value behavior on the `value` attribute to make the validation work.

--- a/src/mdc/text-field/mdc-text-field.html
+++ b/src/mdc/text-field/mdc-text-field.html
@@ -2,7 +2,7 @@
        <div class="mdc-text-field">
               <input id="${id}-input" 
                      type="${type}" 
-                     class="mdc-text-field__input" autofocus.bind="autofocus" autocomplete.bind="autocomplete" 
+                     class="mdc-text-field__input" autocomplete.bind="autocomplete" 
                      value.bind="value | textFieldInput:type">
               <label id="${id}-label" 
                      class="mdc-floating-label ${prefilled?'mdc-floating-label--float-above':''}" 

--- a/src/mdc/text-field/mdc-text-field.html
+++ b/src/mdc/text-field/mdc-text-field.html
@@ -1,22 +1,24 @@
 <template id="${id}">
-    <div class="mdc-text-field" validation-errors.bind="valErrors">
-        <input id="${id}-input"
-               type="${type}" 
-               class="mdc-text-field__input" autofocus.bind="autofocus" autocomplete.bind="autocomplete"
-               value.bind="model[property] | textFieldInput:type & validate">
-        <label id="${id}-label" 
-               class="mdc-floating-label ${prefilled?'mdc-floating-label--float-above':''}"
-               for="${id}-input">${label}</label>
-        <div class="mdc-line-ripple"></div>
-    </div>
-    <p id="${id}-helpertext-val-msg" 
-       class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent error" 
-       aria-hidden="true"
-       if.bind="valErrors.length>0">
-        <span class="help-block" repeat.for="errorInfo of valErrors">${errorInfo.error.message}</span>
-    </p>
-    <p id="${id}-helpertext" 
-       class="mdc-text-field-helper-text" 
-       aria-hidden="true"
-       if.bind="valErrors.length==0 && helperText">${helperText}</p>
+       <div class="mdc-text-field">
+              <input id="${id}-input" 
+                     type="${type}" 
+                     class="mdc-text-field__input" autofocus.bind="autofocus" autocomplete.bind="autocomplete" 
+                     value.bind="value | textFieldInput:type">
+              <label id="${id}-label" 
+                     class="mdc-floating-label ${prefilled?'mdc-floating-label--float-above':''}" 
+                     for="${id}-input">${label}</label>
+              <div class="mdc-line-ripple"></div>
+       </div>
+       <p id="${id}-helpertext-val-msg" 
+          class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg"
+          aria-hidden="true" 
+          if.bind="validationErrors.length>0">
+          <span class="help-block" repeat.for="error of validationErrors">${error}</span>
+       </p>
+       <p id="${id}-helpertext" 
+          class="mdc-text-field-helper-text" 
+          aria-hidden="true" 
+          if.bind="validationErrors.length==0 && helperText">
+              ${helperText}
+       </p>
 </template>

--- a/src/mdc/text-field/mdc-text-field.scss
+++ b/src/mdc/text-field/mdc-text-field.scss
@@ -7,13 +7,12 @@ mdc-text-field {
         width: 100%;
         background-color: transparent;
     }
-
-    .error {
-        //color: $mdc-text-field-error !important;
-        color: red !important;
-    }
-
+    
     .mdc-text-field-helper-text {
         padding-bottom: 6px;
+    }
+
+    .mdc-text-field-helper-text--validation-msg {
+        color: red !important;
     }
 }

--- a/src/mdc/text-field/mdc-text-field.ts
+++ b/src/mdc/text-field/mdc-text-field.ts
@@ -9,11 +9,11 @@ export class MdcTextField {
     @bindable label: string; // translate via t="[label]translatekey"
     @bindable({ defaultBindingMode: bindingMode.fromView }) value: string | number | null;
     @bindable type: string = "text";
-    @bindable required: boolean = true;
-    @bindable disabled: boolean = false;
-    @bindable maxlength: number | undefined = undefined;
+    @bindable required: boolean|string = true;
+    @bindable disabled: boolean|string = false;
+    @bindable maxlength: number|string|undefined = undefined;
     @bindable helperText: string;
-    @bindable autofocus: boolean = false;
+    @bindable autofocus: boolean|string = false;
     @bindable autocomplete: string = "on";
     @bindable validationErrors: any[] = [];
 
@@ -41,14 +41,25 @@ export class MdcTextField {
         }
 
         const inputElement = this.element.querySelector("input");
-        if (inputElement && this.required) {
-            inputElement.setAttribute("required", "true");
-        }
-        if (inputElement && this.disabled) {
-            inputElement.setAttribute("disabled", "disabled");
-        }
-        if (inputElement && this.maxlength) {
-            inputElement.setAttribute("maxlength", this.maxlength.toString());
+        if(inputElement) {
+            if (this.required == true || 
+                this.required == "true" || 
+                this.required == "required") {
+                inputElement.setAttribute("required", "");
+            }
+            if (this.disabled == true ||
+                this.disabled == "true" ||
+                this.disabled == "disabled") {
+                inputElement.setAttribute("disabled", "");
+            }
+            if (this.autofocus == true ||
+                this.autofocus == "true" ||
+                this.autofocus == "autofocus") {
+                inputElement.setAttribute("autofocus", "");
+            }
+            if (this.maxlength) {
+                inputElement.setAttribute("maxlength", this.maxlength.toString());
+            }
         }
 
         const textFieldElement = this.element.querySelector(".mdc-text-field");

--- a/src/mdc/text-field/mdc-text-field.ts
+++ b/src/mdc/text-field/mdc-text-field.ts
@@ -1,4 +1,4 @@
-import { bindable, autoinject, computedFrom } from 'aurelia-framework';
+import { bindable, autoinject, bindingMode } from 'aurelia-framework';
 import { MDCTextField } from '@material/textfield/dist/mdc.textfield';
 import './mdc-text-field.scss';
 
@@ -7,42 +7,37 @@ export class MdcTextField {
     textField: MDCTextField;
     @bindable id: string;
     @bindable label: string; // translate via t="[label]translatekey"
-    @bindable model: object;
-    @bindable property: string = "value";
+    @bindable({ defaultBindingMode: bindingMode.fromView }) value: string | number | null;
     @bindable type: string = "text";
     @bindable required: boolean = true;
     @bindable disabled: boolean = false;
-    @bindable maxlength: number|undefined = undefined;
+    @bindable maxlength: number | undefined = undefined;
     @bindable helperText: string;
     @bindable autofocus: boolean = false;
     @bindable autocomplete: string = "on";
-    valErrors: string[] = [];
+    @bindable validationErrors: any[] = [];
 
     constructor(private element: Element) {
     }
 
     get prefilled(): boolean {
-        if(this.textField) {
-            if(document.activeElement == this.textField.input_) 
+        if (this.textField) {
+            if (document.activeElement == this.textField.input_)
                 return true;
 
-            return this.model[this.property];
+            return this.value != undefined && this.value !== "" && this.value != null;
         }
         return false;
     }
 
     public created() {
         var isIE11 = (navigator.userAgent.indexOf("Trident") > 0);
-        if(this.type=="date" && isIE11) this.type = "text";
+        if (this.type == "date" && isIE11) this.type = "text";
     }
 
     bind(context) {
-        if(this.id === undefined) {
+        if (this.id === undefined) {
             console.error("id not defined");
-        }
-
-        if(!this.model) {
-            this.model = context;
         }
 
         const inputElement = this.element.querySelector("input");
@@ -58,7 +53,7 @@ export class MdcTextField {
 
         const textFieldElement = this.element.querySelector(".mdc-text-field");
         if (textFieldElement && this.disabled) {
-            textFieldElement.classList.add("mdc-text-field--disabled");        
+            textFieldElement.classList.add("mdc-text-field--disabled");
         }
     }
 
@@ -68,9 +63,8 @@ export class MdcTextField {
 
         // override isValid
         const foundation = this.textField.foundation_;
-        var self = this;
-        foundation.isValid = () : boolean => {
-            return self.valErrors.length == 0;
+        foundation.isValid = (): boolean => {
+            return this.validationErrors.length == 0;
         };
     }
 


### PR DESCRIPTION
No more model="model" and property = "prop" in mdc-text-field.